### PR TITLE
Deprecated components from hierarchy gRPC

### DIFF
--- a/hierarchy/grpcapi.proto
+++ b/hierarchy/grpcapi.proto
@@ -105,6 +105,7 @@ enum LubricantUnit {
 }
 
 message Component {
+  option deprecated = true;
   string id = 1;
   string type = 2;
   string props = 3;
@@ -119,7 +120,7 @@ message AssetNode {
   string manufacturer = 5;
   string model = 6;
   string serialNumber = 7;
-  repeated Component components = 9;
+  repeated Component components = 9 [deprecated=true];
 }
 
 message Node {


### PR DESCRIPTION
The components (bearing on asset) have moved to own REST endpoints and are no longer available directly on an asset. 