### PR TITLE
Add rate of change to node data

### DIFF
--- a/pas/grpcapi.proto
+++ b/pas/grpcapi.proto
@@ -37,6 +37,7 @@ message NodeData {
   Media media_v2 = 9;
   string measurement_id = 10;
   string tags = 11;
+  DoubleObject rate_of_change = 12;
 }
 enum NodeDataContentType {
   DEFAULT = 0;


### PR DESCRIPTION
The rate of change on a measurement is needed in cases where a rate of change alarm status is to be recalculated.