### PR TITLE
Add enum for relative overall band alarm

### DIFF
--- a/pas/grpcapi.proto
+++ b/pas/grpcapi.proto
@@ -276,6 +276,7 @@ message ThresholdValue {
     UNKNOWN = 0;
     ABSOLUTE = 1;
     RELATIVE_FULLSCALE = 2;
+    RELATIVE_OVERALL = 3;
   }
 }
 


### PR DESCRIPTION
Adds a enum to the threshold value type for band alarms. This enum will signify that the alarm levels are relative to the configured overall alarm levels.